### PR TITLE
allow viewing old events on eventsclient by refactoring event selection to page

### DIFF
--- a/app/components/EventsClient.test.tsx
+++ b/app/components/EventsClient.test.tsx
@@ -273,53 +273,53 @@ describe('EventsClient registered badge', () => {
 })
 
 describe('EventsClient scroll lock', () => {
+  const weeks = [
+    {
+      weekStart: new Date('2026-02-09T00:00:00Z'),
+      weekEnd: new Date('2026-02-16T00:00:00Z'),
+      weekNumber: 5,
+      seasonYear: 2026,
+      seasonQuarter: 1,
+      official: true,
+      meta: {
+        events: 1,
+        tracks: ['Daytona'],
+        classes: ['IMSA23'],
+      },
+      events: [
+        {
+          id: 'event-1',
+          name: 'IMSA Endurance Series - 2026 Season 1 - Week 5',
+          startTime: new Date('2026-02-15T06:00:00Z'),
+          endTime: new Date('2026-02-15T08:00:00Z'),
+          licenseGroup: 'C',
+          durationMins: 120,
+          track: 'Daytona',
+          trackConfig: 'Road',
+          externalId: null,
+          tempValue: null,
+          tempUnits: null,
+          relHumidity: null,
+          skies: null,
+          precipChance: null,
+          description: null,
+          carClasses: [{ id: 'class-1', name: 'IMSA23', shortName: 'IMSA23' }],
+          races: [
+            {
+              id: 'race-1',
+              startTime: new Date('2026-02-15T06:00:00Z'),
+              endTime: new Date('2026-02-15T08:00:00Z'),
+              registrations: [],
+            },
+          ],
+        },
+      ],
+    },
+  ] as any
+
   it('locks page scrolling while the event modal is open', async () => {
     document.body.style.overflow = ''
     document.documentElement.style.overflow = ''
-
-    const weeks = [
-      {
-        weekStart: new Date('2026-02-09T00:00:00Z'),
-        weekEnd: new Date('2026-02-16T00:00:00Z'),
-        weekNumber: 5,
-        seasonYear: 2026,
-        seasonQuarter: 1,
-        official: true,
-        meta: {
-          events: 1,
-          tracks: ['Daytona'],
-          classes: ['IMSA23'],
-        },
-        events: [
-          {
-            id: 'event-1',
-            name: 'IMSA Endurance Series - 2026 Season 1 - Week 5',
-            startTime: new Date('2026-02-15T06:00:00Z'),
-            endTime: new Date('2026-02-15T08:00:00Z'),
-            licenseGroup: 'C',
-            durationMins: 120,
-            track: 'Daytona',
-            trackConfig: 'Road',
-            externalId: null,
-            tempValue: null,
-            tempUnits: null,
-            relHumidity: null,
-            skies: null,
-            precipChance: null,
-            description: null,
-            carClasses: [{ id: 'class-1', name: 'IMSA23', shortName: 'IMSA23' }],
-            races: [
-              {
-                id: 'race-1',
-                startTime: new Date('2026-02-15T06:00:00Z'),
-                endTime: new Date('2026-02-15T08:00:00Z'),
-                registrations: [],
-              },
-            ],
-          },
-        ],
-      },
-    ] as any
 
     render(
       <EventsClient
@@ -327,6 +327,7 @@ describe('EventsClient scroll lock', () => {
         isAdmin={false}
         userId="user-1"
         userLicenseLevel={null}
+        selectedEvent={weeks[0].events[0]}
         teams={[]}
       />
     )
@@ -334,15 +335,31 @@ describe('EventsClient scroll lock', () => {
     const eventButton = screen.getAllByRole('button')[0]
     fireEvent.click(eventButton)
 
-    expect(screen.getByTestId('event-modal')).toBeInTheDocument()
+    expect(screen.queryByTestId('event-modal')).toBeInTheDocument()
     expect(document.body.style.overflow).toBe('hidden')
     expect(document.documentElement.style.overflow).toBe('hidden')
+    const urlParams = new URLSearchParams(window.location.search)
+    expect(urlParams.has('eventId'))
 
     fireEvent.click(screen.getByRole('button', { name: 'Close Modal' }))
+    const urlParamsAfter = new URLSearchParams(window.location.search)
+    expect(!urlParamsAfter.has('eventId'))
+  })
 
-    await waitFor(() => {
-      expect(document.body.style.overflow).toBe('')
-      expect(document.documentElement.style.overflow).toBe('')
-    })
+  it('should not render details modal with no selected event', () => {
+    render(
+      <EventsClient
+        weeks={weeks}
+        isAdmin={false}
+        userId="user-1"
+        userLicenseLevel={null}
+        selectedEvent={null}
+        teams={[]}
+      />
+    )
+
+    expect(screen.queryByTestId('event-modal')).not.toBeInTheDocument()
+    expect(document.body.style.overflow).toBe('')
+    expect(document.documentElement.style.overflow).toBe('')
   })
 })

--- a/app/components/EventsClient.tsx
+++ b/app/components/EventsClient.tsx
@@ -1,6 +1,6 @@
 ﻿'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import EventDetailModal from './EventDetailModal'
 import { Prisma } from '@prisma/client'
@@ -60,9 +60,9 @@ interface EventsClientProps {
   isAdmin: boolean
   userId: string
   userLicenseLevel: LicenseLevel | null
-  initialEventId?: string
   teams: Array<{ id: string; name: string; iracingTeamId: number | null; memberCount?: number }>
   discordGuildId?: string
+  selectedEvent?: EventWithRaces | null
 }
 
 export default function EventsClient({
@@ -70,18 +70,12 @@ export default function EventsClient({
   isAdmin,
   userId,
   userLicenseLevel,
-  initialEventId,
   teams,
   discordGuildId,
+  selectedEvent,
 }: EventsClientProps) {
   const router = useRouter()
-  const [selectedEventId, setSelectedEventId] = useState<string | null>(initialEventId ?? null)
   const now = new Date()
-
-  const selectedEvent = useMemo(() => {
-    if (!selectedEventId) return null
-    return weeks.flatMap((week) => week.events).find((evt) => evt.id === selectedEventId) || null
-  }, [selectedEventId, weeks])
 
   useEffect(() => {
     if (!selectedEvent) return
@@ -100,13 +94,11 @@ export default function EventsClient({
 
   // Update URL when event is selected
   const handleSelectEvent = (event: EventWithRaces) => {
-    setSelectedEventId(event.id)
     router.push(`?eventId=${event.id}`, { scroll: false })
   }
 
   // Clear URL when modal is closed
   const handleCloseModal = () => {
-    setSelectedEventId(null)
     router.push('?', { scroll: false })
   }
 

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -6,6 +6,7 @@ import LastSyncStatus from '@/components/LastSyncStatus'
 import EventsClient from '../components/EventsClient'
 import { Prisma } from '@prisma/client'
 import { getLicenseLevelFromName, getLicenseForId, isLicenseEligible } from '@/lib/utils'
+import { getEvent } from '@/lib/queries'
 
 import styles from './events.module.css'
 import { getIracingSeasonInfo } from '@/lib/season-utils'
@@ -349,6 +350,11 @@ export default async function EventsPage({ searchParams }: PageProps) {
     },
   }))
 
+  // Find the selected event from search params
+  const selectedEvent = params.eventId
+    ? events.find((event) => event.id === params.eventId) || (await getEvent(params.eventId))
+    : null
+
   return (
     <main className={styles.main}>
       <div className={styles.topRow}>
@@ -365,9 +371,9 @@ export default async function EventsPage({ searchParams }: PageProps) {
         isAdmin={session.user.role === 'ADMIN'}
         userId={session.user.id}
         userLicenseLevel={userLicenseLevel}
-        initialEventId={params.eventId}
         teams={teams}
         discordGuildId={process.env.DISCORD_GUILD_ID}
+        selectedEvent={selectedEvent}
       />
     </main>
   )

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -1,0 +1,26 @@
+import prisma from './prisma'
+
+export async function getEvent(eventId: string) {
+  return await prisma.event.findFirst({
+    where: { id: eventId },
+    include: {
+      carClasses: true,
+      races: {
+        include: {
+          registrations: {
+            include: {
+              user: {
+                include: {
+                  racerStats: true,
+                },
+              },
+              carClass: true,
+              team: true,
+              manualDriver: true,
+            },
+          },
+        },
+      },
+    },
+  })
+}


### PR DESCRIPTION
Fixes #103 
https://streamable.com/uw5q2x 

Previously the event detail state was managed within the EventsClient component on the client side. This meant that the client was unable to show any older event that is not in the weeks prop.

I tried to fix this by allowing the client side to make a prisma call, however, this is only allowed within the server component. At this point, the event selection is now moved to the page.tsx functionality. The EventsClient now takes in a weeks prop with all of the events, and a selectedEvent prop that shows which is the current event selected.

The event selection works by modifying the existing callback handlers in the EventsClient component to only modify the URL Search parameters, affecting the /events?id=aiofnweuibfnauil functionality